### PR TITLE
CAS commit correctness (deterministic reservation & removal of non-transactional writes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![issues - stmsharp](https://img.shields.io/github/issues/engineering87/stmsharp)](https://github.com/engineering87/stmsharp/issues)
 [![stars - stmsharp](https://img.shields.io/github/stars/engineering87/stmsharp?style=social)](https://github.com/engineering87/stmsharp)
 
-STMSharp brings Software Transactional Memory to .NET: write your concurrent logic as atomic transactions over shared variables, with optimistic snapshots and a lock-free CAS commit that prevents lost updates under contention.
+**STMSharp** brings **Software Transactional Memory** to .NET: write your concurrent logic as atomic transactions over shared variables, with optimistic snapshots and a lock-free CAS commit that prevents lost updates under contention.
 
 ## Features
 - **Transaction-based memory model:** Manage and update shared variables without needing locks.
@@ -19,14 +19,14 @@ STMSharp brings Software Transactional Memory to .NET: write your concurrent log
 ## What is Software Transactional Memory (STM)?
 Software Transactional Memory (STM) is a concurrency control mechanism that simplifies writing concurrent programs by providing an abstraction similar to database transactions. STM allows developers to work with shared memory without the need for explicit locks, reducing the complexity of concurrent programming.
 
-### Key Concepts of STM:
+## Key Concepts of STM:
 - **Transactions:** Operations on shared variables are grouped into transactions. A transaction is a unit of work that must be executed atomically.
 - **Atomicity:** A transaction is executed as a single, indivisible operation. Either all operations within the transaction are completed, or none are, ensuring consistency.
 - **Isolation:** Transactions are isolated from each other, meaning that the operations in one transaction do not interfere with others, even if they are executed concurrently.
 - **Conflict Detection:** STM systems track changes to shared variables and detect conflicts when two or more transactions try to modify the same variable. If a conflict is detected, the system retries the transaction or resolves it according to a conflict resolution strategy.
 - **Composability:** STM transactions can be nested or composed together, making it easier to structure complex operations.
 
-### Benefits of STM:
+## Benefits of STM:
 - **Simplified concurrency control:** STM eliminates the need for low-level synchronization mechanisms like locks, reducing the potential for deadlocks and race conditions.
 - **Scalability:** STM can scale more effectively than traditional lock-based systems, especially in highly concurrent environments.
 - **Composability and Modularity:** STM makes it easier to compose complex operations from simple ones, which promotes cleaner and more modular code.
@@ -47,12 +47,38 @@ In STMSharp, STM is implemented using transactions that read from and write to S
 
 This ensures serializability and prevents lost updates without runtime locks.
 
-### Core Components:
+## Core Components:
 1. **Transaction<T>:** The main class representing a transaction. It allows reading from and writing to STM variables.
 2. **STMVariable<T>:** A type that encapsulates the shared data and supports STM operations (read/write).
 3. **STMEngine:** Provides static methods for managing transactions and conflict resolution.
 
-### How to use it
+## CAS & the internal protocol
+STMSharp uses an even/odd version scheme and Compare-And-Exchange (CAS) to coordinate writers:
+- **Invariants**
+    - Even version ⇒ variable is free (no writer holds a reservation).
+    - Odd version ⇒ variable is reserved by some writer during a commit attempt.
+    - Only the transactional path mutates state; non-transactional writes are not exposed.
+- **Reserve (CAS)**
+    ```csharp
+    // success only if current == snapshotVersion (even)
+    // sets version to snapshotVersion + 1 (odd), meaning "reserved"
+    Interlocked.CompareExchange(ref version, snapshotVersion + 1, snapshotVersion);
+    ```
+- **Revalidation**
+    - For each read-set entry: `currentVersion == snapshotVersion` and `(currentVersion & 1) == 0`.
+    - For each write-set entry: already reserved by the current commit; skip.
+- **Write & release**
+    - Write the new value, then `Interlocked.Increment(ref version)` to turn `odd → even` (commit complete).
+    - On abort, `ReleaseAfterAbort()` also increments once to revert `odd → even`.
+- **Deterministic ordering**
+    - All reservations over the write-set are attempted in a stable order (based on reference identity) to reduce livelock under contention.
+    - On failure, only the already acquired reservations are released, in reverse order.
+- **Snapshots**
+    - The first observation of a variable (read or write-first) captures an immutable `(value, version)` pair used both for validation and reservation.
+- **Why no non-transactional writes?**
+    - To preserve the invariants and prevent out-of-band mutations from violating the even/odd protocol, `ISTMVariable<T>` exposes only `ReadWithVersion()` and `Version`. Writes occur exclusively via the transactional commit path.
+
+## How to use it
 Here's a basic example of how to use STMSharp in your project:
 
 ```csharp
@@ -114,8 +140,8 @@ If you'd like to contribute, please fork, fix, commit and send a pull request fo
  * [Fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
  * [Open an issue](https://github.com/engineering87/stmsharp/issues) if you encounter a bug or have a suggestion for improvements/features
 
-### License
+## License
 STMSharp source code is available under MIT License, see license in the source.
 
-### Contact
+## Contact
 Please contact at francesco.delre[at]protonmail.com for any details.

--- a/src/STMSharp.Benchmarking/appsettings.json
+++ b/src/STMSharp.Benchmarking/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "NumberOfThreads": 10,
-  "NumberOfOperations": 100,
-  "BackoffTime": 100,
+  "NumberOfOperations": 200,
+  "BackoffTime": 150,
   "ProcessingTime": 30,
   "MaxAttempts": 5
 }

--- a/src/STMSharp.PerformanceTests/Benchmarks/STMPerformanceBenchmark.cs
+++ b/src/STMSharp.PerformanceTests/Benchmarks/STMPerformanceBenchmark.cs
@@ -1,29 +1,62 @@
 ﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
+
+using System.Threading;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
 using STMSharp.Core;
 using STMSharp.Enum;
 
 namespace STMSharp.PerformanceTests.Benchmarks
 {
+    /// <summary>
+    /// Simple end-to-end STM benchmarks used by Program.cs to summarize mean times by Backoff type.
+    /// Notes:
+    /// - Job runtime aligned to .NET 9 (Net90) to match the project TFM (net9.0).
+    /// - State is reset per iteration to avoid cross-iteration skew.
+    /// - Keep method names 'AtomicWrite' and 'AtomicReadOnly' for Program.cs aggregation.
+    /// </summary>
     [MemoryDiagnoser]
     [RankColumn]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest)]
+    [HideColumns("StdDev")] // modern BDN: hide by column name
+    [SimpleJob(RuntimeMoniker.Net90, launchCount: 1, warmupCount: 3, iterationCount: 10)]
     public class STMPerformanceBenchmark
     {
-        private STMVariable<int> _variable;
+        private STMVariable<int> _variable = default!;
 
+        // Backoff type is the key used by Program.cs to group results
         [Params(BackoffType.Exponential, BackoffType.ExponentialWithJitter, BackoffType.Linear, BackoffType.Constant)]
-        public BackoffType Backoff;
+        public BackoffType Backoff { get; set; }
+
+        // Small knobs to make runs comparable and reproducible
+        [Params(16)]
+        public int MaxAttempts { get; set; }
+
+        [Params(2)]
+        public int InitialBackoffMilliseconds { get; set; }
 
         [GlobalSetup]
-        public void Setup()
+        public void GlobalSetup()
         {
             _variable = new STMVariable<int>(0);
         }
 
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            // Ensure each iteration starts from a clean state
+            _variable = new STMVariable<int>(0);
+        }
+
+        // ---------------- Baselines (non-transactional) ----------------
+
         [Benchmark(Baseline = true)]
         public int WriteVariable()
         {
+            // direct non-transactional write (for reference)
             _variable.Write(_variable.Read() + 1);
             return _variable.Read();
         }
@@ -31,26 +64,39 @@ namespace STMSharp.PerformanceTests.Benchmarks
         [Benchmark]
         public int ReadVariable()
         {
+            // direct non-transactional read
             return _variable.Read();
         }
+
+        // ---------------- Transactional ----------------
 
         [Benchmark]
         public async Task AtomicWrite()
         {
-            await STMEngine.Atomic<int>(transaction =>
+            await STMEngine.Atomic<int>(tx =>
             {
-                var value = transaction.Read(_variable);
-                transaction.Write(_variable, value + 1);
-            }, maxAttempts: 3, initialBackoffMilliseconds: 50, backoffType: Backoff);
+                var value = tx.Read(_variable);
+                tx.Write(_variable, value + 1);
+            },
+            maxAttempts: MaxAttempts,
+            initialBackoffMilliseconds: InitialBackoffMilliseconds,
+            backoffType: Backoff,
+            readOnly: false,
+            cancellationToken: CancellationToken.None);
         }
 
         [Benchmark]
         public async Task AtomicReadOnly()
         {
-            await STMEngine.Atomic<int>(transaction =>
+            await STMEngine.Atomic<int>(tx =>
             {
-                var value = transaction.Read(_variable);
-            }, maxAttempts: 3, initialBackoffMilliseconds: 50, backoffType: Backoff, readOnly: true);
+                var _ = tx.Read(_variable);
+            },
+            maxAttempts: MaxAttempts,
+            initialBackoffMilliseconds: InitialBackoffMilliseconds,
+            backoffType: Backoff,
+            readOnly: true,
+            cancellationToken: CancellationToken.None);
         }
     }
 }

--- a/src/STMSharp.Tests/STMSharp.Tests.csproj
+++ b/src/STMSharp.Tests/STMSharp.Tests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/STMSharp.Tests/STMTests.cs
+++ b/src/STMSharp.Tests/STMTests.cs
@@ -1,144 +1,371 @@
-// (c) 2024 Francesco Del Re <francesco.delre.87@gmail.com>
+﻿// (c) 2024-2025 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using STMSharp.Core;
+using STMSharp.Enum;
 
 namespace STMSharp.Tests
 {
+    // Prevent parallel execution across these tests (static counters + shared state).
+    [CollectionDefinition("STM non-parallel")]
+    public class STMNonParallelCollection : ICollectionFixture<object> { }
+
+    [Collection("STM non-parallel")]
     public class STMTests
     {
-        private async Task<int> ReadInsideTransactionAsync(STMVariable<int> sharedVar)
+        // -------- Helpers --------
+
+        private static void ResetStats() => Transaction<int>.ResetCounters();
+
+        /// <summary>
+        /// Runs an async body with a hard timeout. Cancels the body if it overruns.
+        /// Ensures tests never hang indefinitely.
+        /// </summary>
+        private static async Task WithTimeout(Func<CancellationToken, Task> body, int timeoutMs = 5_000)
+        {
+            using var cts = new CancellationTokenSource(timeoutMs);
+            var task = body(cts.Token);
+            var completed = await Task.WhenAny(task, Task.Delay(timeoutMs, CancellationToken.None));
+            if (completed != task)
+            {
+                cts.Cancel();
+                throw new TimeoutException($"Test exceeded {timeoutMs} ms.");
+            }
+            await task; // surface exceptions
+        }
+
+        /// <summary>
+        /// Creates a start gate that releases tasks simultaneously.
+        /// </summary>
+        private static TaskCompletionSource<bool> NewStartGate()
+            => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Reads the variable inside a transaction to respect STM semantics.
+        /// </summary>
+        private static async Task<int> ReadInsideTransactionAsync(STMVariable<int> v)
         {
             int result = 0;
-            await STMEngine.Atomic<int>((transaction) =>
-            {
-                result = transaction.Read(sharedVar);
-            });
+            await STMEngine.Atomic<int>(tx => { result = tx.Read(v); });
             return result;
         }
 
+        // -------- Tests --------
+
         [Fact]
-        public async Task TestTransactionWithBackoffAsync()
+        public async Task SequentialTwoIncrements_AreApplied()
         {
-            var sharedVar = new STMVariable<int>(0);
+            ResetStats();
+            var shared = new STMVariable<int>(0);
 
-            await STMEngine.Atomic<int>((transaction) =>
+            await STMEngine.Atomic<int>(tx =>
             {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
+                var val = tx.Read(shared);
+                tx.Write(shared, val + 1);
             });
 
-            await STMEngine.Atomic<int>((transaction) =>
+            await STMEngine.Atomic<int>(tx =>
             {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
+                var val = tx.Read(shared);
+                tx.Write(shared, val + 1);
             });
 
-            Assert.Equal(2, await ReadInsideTransactionAsync(sharedVar));
+            Assert.Equal(2, await ReadInsideTransactionAsync(shared));
+            Assert.True(Transaction<int>.RetryCount >= 0);
         }
 
         [Fact]
-        public async Task TestTransactionWithConflictAsync()
+        public async Task TwoConcurrentIncrements_NoLostUpdates()
         {
-            var sharedVar = new STMVariable<int>(0);
+            ResetStats();
+            var shared = new STMVariable<int>(0);
 
-            var task1 = STMEngine.Atomic<int>((transaction) =>
+            await WithTimeout(async ct =>
             {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
+                var start = NewStartGate();
 
-            var task2 = STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            await Task.WhenAll(task1, task2);
-
-            Assert.Equal(2, await ReadInsideTransactionAsync(sharedVar));
-        }
-
-        [Fact]
-        public async Task TestTransactionWithMultipleRetriesAsync()
-        {
-            var sharedVar = new STMVariable<int>(0);
-
-            var task1 = STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            var task2 = STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            await Task.WhenAll(task1, task2);
-
-            Assert.Equal(2, await ReadInsideTransactionAsync(sharedVar));
-        }
-
-        [Fact]
-        public async Task TestTransactionWithNoConflictAsync()
-        {
-            var sharedVar = new STMVariable<int>(0);
-
-            await STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            await STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            Assert.Equal(2, await ReadInsideTransactionAsync(sharedVar));
-        }
-
-        [Fact]
-        public async Task TestTransactionWithMaxAttemptsAsync()
-        {
-            var sharedVar = new STMVariable<int>(0);
-
-            var task1 = STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            var task2 = STMEngine.Atomic<int>((transaction) =>
-            {
-                var value = transaction.Read(sharedVar);
-                transaction.Write(sharedVar, value + 1);
-            });
-
-            await Task.WhenAll(task1, task2);
-
-            Assert.Equal(2, await ReadInsideTransactionAsync(sharedVar));
-        }
-
-        [Fact]
-        public async Task TestHighContentionWithMultipleTransactionsAsync()
-        {
-            var sharedVar = new STMVariable<int>(0);
-            const int transactionCount = 10;
-
-            var tasks = Enumerable.Range(0, transactionCount).Select(_ =>
-                STMEngine.Atomic<int>((transaction) =>
+                var t1 = Task.Run(async () =>
                 {
-                    var value = transaction.Read(sharedVar);
-                    transaction.Write(sharedVar, value + 1);
-                })
-            ).ToList();
+                    await start.Task;
+                    await STMEngine.Atomic<int>(tx =>
+                    {
+                        var v = tx.Read(shared);
+                        tx.Write(shared, v + 1);
+                    }, maxAttempts: 12, initialBackoffMilliseconds: 1,
+                       backoffType: BackoffType.ExponentialWithJitter, cancellationToken: ct);
+                }, ct);
 
-            await Task.WhenAll(tasks);
+                var t2 = Task.Run(async () =>
+                {
+                    await start.Task;
+                    await STMEngine.Atomic<int>(tx =>
+                    {
+                        var v = tx.Read(shared);
+                        tx.Write(shared, v + 1);
+                    }, maxAttempts: 12, initialBackoffMilliseconds: 1,
+                       backoffType: BackoffType.ExponentialWithJitter, cancellationToken: ct);
+                }, ct);
 
-            Assert.Equal(transactionCount, await ReadInsideTransactionAsync(sharedVar));
+                start.SetResult(true);
+                await Task.WhenAll(t1, t2);
+            });
+
+            // Check only the actual shared variable
+            Assert.Equal(2, await ReadInsideTransactionAsync(shared));
+        }
+
+        [Fact]
+        public async Task HighContention_FinishesFast_NoDeadlocks()
+        {
+            ResetStats();
+            var shared = new STMVariable<int>(0);
+            const int writers = 32;
+
+            await WithTimeout(async ct =>
+            {
+                var start = NewStartGate();
+
+                var tasks = Enumerable.Range(0, writers).Select(_ => Task.Run(async () =>
+                {
+                    await start.Task;
+                    await STMEngine.Atomic<int>(tx =>
+                    {
+                        var v = tx.Read(shared);
+                        tx.Write(shared, v + 1);
+                    },
+                    maxAttempts: 64,                   // more attempts to avoid rare miss under high contention
+                    initialBackoffMilliseconds: 2,     // slight backoff to reduce thrash
+                    backoffType: BackoffType.ExponentialWithJitter,
+                    cancellationToken: ct);
+                }, ct)).ToArray();
+
+                start.SetResult(true);
+                await Task.WhenAll(tasks);
+            }, timeoutMs: 10_000); // more generous on CI
+
+            var final = await ReadInsideTransactionAsync(shared);
+
+            // On failure, show diagnostic counters
+            Assert.True(final == writers,
+                $"Final={final}, Expected={writers}, Retries={Transaction<int>.RetryCount}, Conflicts={Transaction<int>.ConflictCount}");
+        }
+
+        [Fact]
+        public async Task ReadOnly_ThrowsOnWrite_Quickly()
+        {
+            ResetStats();
+            var x = new STMVariable<int>(0);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                WithTimeout(ct => STMEngine.Atomic<int>(tx =>
+                {
+                    var v = tx.Read(x);
+                    tx.Write(x, v + 1); // must throw inside read-only transaction
+                }, readOnly: true, cancellationToken: ct))
+            );
+        }
+
+        [Fact]
+        public async Task Stats_ConflictsAndRetries_AreTrackedNonNegative()
+        {
+            ResetStats();
+            var shared = new STMVariable<int>(0);
+
+            await WithTimeout(async ct =>
+            {
+                var start = NewStartGate();
+
+                var t1 = Task.Run(async () =>
+                {
+                    await start.Task;
+                    await STMEngine.Atomic<int>(tx =>
+                    {
+                        var v = tx.Read(shared);
+                        tx.Write(shared, v + 1);
+                    }, maxAttempts: 12, initialBackoffMilliseconds: 1,
+                       backoffType: BackoffType.ExponentialWithJitter, cancellationToken: ct);
+                }, ct);
+
+                var t2 = Task.Run(async () =>
+                {
+                    await start.Task;
+                    await STMEngine.Atomic<int>(tx =>
+                    {
+                        var v = tx.Read(shared);
+                        tx.Write(shared, v + 1);
+                    }, maxAttempts: 12, initialBackoffMilliseconds: 1,
+                       backoffType: BackoffType.ExponentialWithJitter, cancellationToken: ct);
+                }, ct);
+
+                start.SetResult(true);
+                await Task.WhenAll(t1, t2);
+            });
+
+            Assert.True(Transaction<int>.RetryCount >= 0);
+            Assert.True(Transaction<int>.ConflictCount >= 0);
+        }
+
+        [Fact]
+        public async Task Timeout_WhenMaxAttemptsIsOne_UnderHeavyContention()
+        {
+            ResetStats();
+            var shared = new STMVariable<int>(0);
+
+            const int contenders = 8;          // keep lower for CI stability
+            const int outerTimeoutMs = 10_000; // external hard timeout
+
+            await WithTimeout(async ct =>
+            {
+                // Start gate
+                var startGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                // Lock-free "read barrier"
+                int readersReady = 0;           // incremented after the READ phase
+                int goWrite = 0;                // 0=hold, 1=release; polled with Volatile
+
+                var tasks = Enumerable.Range(0, contenders).Select(_ => Task.Run(async () =>
+                {
+                    await startGate.Task;
+
+                    try
+                    {
+                        await STMEngine.Atomic<int>(tx =>
+                        {
+                            // 1) READ phase: all contenders capture the same snapshot
+                            var v = tx.Read(shared);
+
+                            // Mark this contender as ready for the write phase
+                            Interlocked.Increment(ref readersReady);
+
+                            // 2) Spin-wait until the write phase is released
+                            var spinner = new SpinWait();
+                            while (Volatile.Read(ref goWrite) == 0)
+                            {
+                                spinner.SpinOnce();
+                                if (ct.IsCancellationRequested) return; // cooperative exit
+                            }
+
+                            // 3) WRITE: with maxAttempts=1, at least one will fail on reservation/validation
+                            tx.Write(shared, v + 1);
+
+                        }, maxAttempts: 1, initialBackoffMilliseconds: 0,
+                           backoffType: BackoffType.ExponentialWithJitter,
+                           cancellationToken: ct);
+
+                        return true; // success
+                    }
+                    catch (TimeoutException)
+                    {
+                        return false; // expected for some contenders
+                    }
+                }, ct)).ToArray();
+
+                // Release all contenders to start
+                startGate.SetResult(true);
+
+                // Wait a short while for most contenders to finish the READ phase (lock-free wait)
+                var waitSpin = new SpinWait();
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                while (Volatile.Read(ref readersReady) < contenders && sw.ElapsedMilliseconds < 2_000)
+                {
+                    waitSpin.SpinOnce();
+                    if (ct.IsCancellationRequested) break;
+                }
+
+                // Release the WRITE phase (even if not all reached it; collision is still forced)
+                Volatile.Write(ref goWrite, 1);
+
+                var results = await Task.WhenAll(tasks);
+
+                // With maxAttempts=1 and near-simultaneous commits, expect both success and failure
+                Assert.Contains(true, results);
+                Assert.Contains(false, results);
+            }, timeoutMs: outerTimeoutMs);
+
+            // Final value must be within bounds (at least one, at most all)
+            var final = await ReadInsideTransactionAsync(shared);
+            Assert.InRange(final, 1, contenders);
+        }
+
+        [Theory]
+        [InlineData(4, 50)]
+        [InlineData(8, 50)]
+        public async Task ThreadsTimesOps_FastAndCorrect(int threads, int ops)
+        {
+            ResetStats();
+            var shared = new STMVariable<int>(0);
+
+            await WithTimeout(async ct =>
+            {
+                var tasks = Enumerable.Range(0, threads).Select(_ => Task.Run(async () =>
+                {
+                    for (int i = 0; i < ops; i++)
+                    {
+                        await STMEngine.Atomic<int>(tx =>
+                        {
+                            var v = tx.Read(shared);
+                            tx.Write(shared, v + 1);
+                        },
+                        maxAttempts: 64,                    // ↑ more attempts to avoid rare misses
+                        initialBackoffMilliseconds: 2,      // ↑ slightly larger backoff to reduce thrash
+                        backoffType: BackoffType.ExponentialWithJitter,
+                        cancellationToken: ct);
+                    }
+                }, ct)).ToArray();
+
+                await Task.WhenAll(tasks);
+            }, timeoutMs: 10_000); // generous test-level guard
+
+            var final = await ReadInsideTransactionAsync(shared);
+            Assert.True(final == threads * ops,
+                $"Final={final}, Expected={threads * ops}, Retries={Transaction<int>.RetryCount}, Conflicts={Transaction<int>.ConflictCount}");
+        }
+
+        [Fact]
+        public async Task ReadOnlyValidationConflict_IsCountedAndReturnsFast()
+        {
+            ResetStats();
+            var x = new STMVariable<int>(0);
+
+            await WithTimeout(async ct =>
+            {
+                var start = NewStartGate();
+
+                var writer = Task.Run(async () =>
+                {
+                    await start.Task;
+                    await STMEngine.Atomic<int>(tx =>
+                    {
+                        var v = tx.Read(x);
+                        tx.Write(x, v + 1);
+                    }, maxAttempts: 8, initialBackoffMilliseconds: 1,
+                       backoffType: BackoffType.ExponentialWithJitter, cancellationToken: ct);
+                }, ct);
+
+                var reader = Task.Run(async () =>
+                {
+                    await start.Task;
+                    // Read-only transaction may see validation conflict under contention
+                    try
+                    {
+                        await STMEngine.Atomic<int>(tx =>
+                        {
+                            var v = tx.Read(x);
+                            // no write
+                        }, readOnly: true, maxAttempts: 2, initialBackoffMilliseconds: 1,
+                           backoffType: BackoffType.ExponentialWithJitter, cancellationToken: ct);
+                    }
+                    catch (TimeoutException)
+                    {
+                        // Acceptable under contention with a small attempt budget
+                    }
+                }, ct);
+
+                start.SetResult(true);
+                await Task.WhenAll(writer, reader);
+            });
+
+            Assert.True(Transaction<int>.RetryCount >= 0);
+            Assert.True(Transaction<int>.ConflictCount >= 0);
         }
     }
 }

--- a/src/STMSharp/Core/Backoff/BackoffPolicy.cs
+++ b/src/STMSharp/Core/Backoff/BackoffPolicy.cs
@@ -6,13 +6,6 @@ namespace STMSharp.Core.Backoff
 {
     public static class BackoffPolicy
     {
-        private static readonly ThreadLocal<Random> _random = new(() => new Random());
-
-        private static int NextRandom(int max)
-        {
-            return _random.Value!.Next(0, max);
-        }
-
         /// <summary>
         /// Calculates the delay in milliseconds to wait before retrying an operation,
         /// based on the specified backoff algorithm and attempt count.
@@ -24,28 +17,28 @@ namespace STMSharp.Core.Backoff
         /// <returns>The delay in milliseconds to wait before the next retry.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if an unsupported backoff type is specified.</exception>
         public static int GetDelayMilliseconds(
-            BackoffType type, 
-            int attempt, 
-            int baseDelay = 100, 
+            BackoffType type,
+            int attempt,
+            int baseDelay = 100,
             int maxDelay = 2000)
         {
-            if (baseDelay <= 0) baseDelay = 1;
-            if (maxDelay <= 0) maxDelay = 1;
+            attempt = Math.Max(0, attempt);
+            baseDelay = Math.Max(1, baseDelay);
+            maxDelay = Math.Max(1, maxDelay);
 
             int CapExp(int a)
             {
-                int shift = Math.Min(a, 30); // overflow protection
-                long v = ((long)baseDelay) << shift;
-                v = Math.Min(v, (long)maxDelay);
-                return (int)Math.Max(1, v);
+                int shift = Math.Min(a, 30); // prevent overflow
+                long value = ((long)baseDelay) << shift;
+                return (int)Math.Clamp(value, 1, maxDelay);
             }
 
             return type switch
             {
                 BackoffType.Exponential => CapExp(attempt),
                 BackoffType.ExponentialWithJitter => Random.Shared.Next(0, CapExp(attempt) + 1),
-                BackoffType.Linear => Math.Min(Math.Max(1, baseDelay * (attempt + 1)), maxDelay),
-                BackoffType.Constant => Math.Max(1, baseDelay),
+                BackoffType.Linear => Math.Min(baseDelay * (attempt + 1), maxDelay),
+                BackoffType.Constant => baseDelay,
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
         }

--- a/src/STMSharp/Core/Interfaces/ISTMVariable.cs
+++ b/src/STMSharp/Core/Interfaces/ISTMVariable.cs
@@ -16,19 +16,8 @@ namespace STMSharp.Core.Interfaces
         (T Value, long Version) ReadWithVersion();
 
         /// <summary>
-        /// Writes a new value atomically to the STM variable.
-        /// </summary>
-        /// <param name="value">The new value to write.</param>
-        void Write(T value);
-
-        /// <summary>
         /// Gets the current version of the variable.
         /// </summary>
         long Version { get; }
-
-        /// <summary>
-        /// Increments the version of the variable.
-        /// </summary>
-        void IncrementVersion();
     }
 }

--- a/src/STMSharp/Core/Interfaces/ISTMVariable.cs
+++ b/src/STMSharp/Core/Interfaces/ISTMVariable.cs
@@ -1,4 +1,4 @@
-﻿// (c) 2024 Francesco Del Re <francesco.delre.87@gmail.com>
+﻿// (c) 2024-2025 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
 namespace STMSharp.Core.Interfaces
@@ -13,7 +13,7 @@ namespace STMSharp.Core.Interfaces
         /// Reads the current value and its version atomically.
         /// </summary>
         /// <returns>A tuple containing the value and its version.</returns>
-        (T Value, int Version) ReadWithVersion();
+        (T Value, long Version) ReadWithVersion();
 
         /// <summary>
         /// Writes a new value atomically to the STM variable.
@@ -24,7 +24,7 @@ namespace STMSharp.Core.Interfaces
         /// <summary>
         /// Gets the current version of the variable.
         /// </summary>
-        int Version { get; }
+        long Version { get; }
 
         /// <summary>
         /// Increments the version of the variable.

--- a/src/STMSharp/Core/STMEngine.cs
+++ b/src/STMSharp/Core/STMEngine.cs
@@ -44,17 +44,22 @@ namespace STMSharp.Core
         private const BackoffType DefaultBackoffType = BackoffType.ExponentialWithJitter;
 
         /// <summary>
-        /// Executes a asynchronous transactional action with automatic retries in case of conflict.
+        /// Executes an asynchronous transactional action with automatic retries in case of conflict.
         /// </summary>
-        /// <typeparam name="T">The return type of the STM transaction.</typeparam>
+        /// <typeparam name="T">
+        /// The type of STM variables involved in the transaction (i.e., Transaction&lt;T&gt;).
+        /// This is not a return type; the method completes when the transaction commits or throws on failure.
+        /// </typeparam>
         /// <param name="action">A user-defined synchronous action containing transactional logic.</param>
         /// <param name="maxAttempts">The maximum number of retry attempts before failing.</param>
         /// <param name="initialBackoffMilliseconds">The base delay used for calculating backoff between retries.</param>
         /// <param name="backoffType">The backoff algorithm to apply on conflict (e.g., exponential, jitter, constant).</param>
         /// <param name="readOnly">Whether the transaction should be executed in read-only mode (disallows writes).</param>
         /// <param name="cancellationToken">Token used to cancel the operation externally.</param>
-        /// <returns>A task that completes once the transaction is successfully committed or throws on failure.</returns>
-
+        /// <returns>
+        /// A task that completes when the transaction is successfully committed; otherwise throws if all attempts fail
+        /// or if the operation is cancelled.
+        /// </returns>
         public static async Task Atomic<T>(
             Action<Transaction<T>> action,
             int maxAttempts = DefaultMaxAttempts,
@@ -74,14 +79,20 @@ namespace STMSharp.Core
         /// <summary>
         /// Executes an asynchronous transactional function with automatic retries in case of conflict.
         /// </summary>
-        /// <typeparam name="T">The return type of the STM transaction.</typeparam>
+        /// <typeparam name="T">
+        /// The type of STM variables involved in the transaction (i.e., Transaction&lt;T&gt;).
+        /// This is not a return type; the method completes when the transaction commits or throws on failure.
+        /// </typeparam>
         /// <param name="func">A user-defined asynchronous function containing transactional logic.</param>
         /// <param name="maxAttempts">The maximum number of retry attempts before failing.</param>
         /// <param name="initialBackoffMilliseconds">The base delay used for calculating backoff between retries.</param>
         /// <param name="backoffType">The backoff algorithm to apply on conflict (e.g., exponential, jitter, constant).</param>
         /// <param name="readOnly">Whether the transaction should be executed in read-only mode (disallows writes).</param>
         /// <param name="cancellationToken">Token used to cancel the operation externally.</param>
-        /// <returns>A task that completes once the transaction is successfully committed or throws on failure.</returns>
+        /// <returns>
+        /// A task that completes when the transaction is successfully committed; otherwise throws if all attempts fail
+        /// or if the operation is cancelled.
+        /// </returns>
         public static async Task Atomic<T>(
             Func<Transaction<T>, Task> func,
             int maxAttempts = DefaultMaxAttempts,

--- a/src/STMSharp/Core/STMEngine.cs
+++ b/src/STMSharp/Core/STMEngine.cs
@@ -91,7 +91,6 @@ namespace STMSharp.Core
             CancellationToken cancellationToken = default)
         {
             int attempt = 0;
-            int backoffTime = initialBackoffMilliseconds;
 
             // Retry loop for transaction attempts
             while (attempt < maxAttempts)

--- a/src/STMSharp/Core/STMVariable.cs
+++ b/src/STMSharp/Core/STMVariable.cs
@@ -17,7 +17,7 @@ namespace STMSharp.Core
     /// - If T is a mutable reference type, external mutations that bypass Write(...) can break isolation
     ///   because the version won't change. Prefer immutable types or treat T as a value.
     /// </summary>
-    public class STMVariable<T> : ISTMVariable<T>
+    public sealed class STMVariable<T> : ISTMVariable<T>
     {
         // Boxed value to support both value types and reference types
         private object _boxedValue;

--- a/src/STMSharp/Core/STMVariable.cs
+++ b/src/STMSharp/Core/STMVariable.cs
@@ -1,17 +1,29 @@
-﻿// (c) 2024 Francesco Del Re <francesco.delre.87@gmail.com>
+﻿// (c) 2024-2025 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
+using System.Runtime.CompilerServices;
 using STMSharp.Core.Interfaces;
 
 namespace STMSharp.Core
 {
     /// <summary>
     /// A thread-safe STM variable that supports both reference and value types.
+    /// 
+    /// Semantics:
+    /// - Writes are visible atomically and advance a monotonic version counter.
+    /// - Readers can obtain a consistent (Value, Version) snapshot using ReadWithVersion().
+    /// - Transactional commit uses internal CAS-based reservation helpers (no runtime locks).
+    ///
+    /// Notes on T:
+    /// - If T is a mutable reference type, external mutations that bypass Write(...) can break isolation
+    ///   because the version won't change. Prefer immutable types or treat T as a value.
     /// </summary>
     public class STMVariable<T> : ISTMVariable<T>
     {
         // Boxed value to support both value types and reference types
         private object _boxedValue;
-        private int _version;
+
+        // Monotonic version; incremented on every successful write or reservation transition
+        private long _version;
 
         public STMVariable(T initialValue)
         {
@@ -29,7 +41,8 @@ namespace STMSharp.Core
         }
 
         /// <summary>
-        /// Writes a new value and increments the version atomically.
+        /// Writes a new value and increments the version atomically
+        /// (if the value actually changed by EqualityComparer).
         /// </summary>
         public void Write(T value)
         {
@@ -42,12 +55,12 @@ namespace STMSharp.Core
         }
 
         /// <summary>
-        /// Returns the current version of the variable for transaction conflict checks.
+        /// Current version of the variable (monotonic).
         /// </summary>
-        public int Version => Volatile.Read(ref _version);
+        public long Version => Volatile.Read(ref _version);
 
         /// <summary>
-        /// Manually increments the version (e.g., for pessimistic versioning).
+        /// Manually increments the version (e.g., for pessimistic schemes or forcing invalidation).
         /// </summary>
         public void IncrementVersion()
         {
@@ -58,10 +71,10 @@ namespace STMSharp.Core
         /// Returns a consistent snapshot of the value and its version.
         /// Ensures that the version did not change during the read.
         /// </summary>
-        public (T Value, int Version) ReadWithVersion()
+        public (T Value, long Version) ReadWithVersion()
         {
             T value;
-            int versionBefore, versionAfter;
+            long versionBefore, versionAfter;
 
             do
             {
@@ -72,6 +85,46 @@ namespace STMSharp.Core
             while (versionBefore != versionAfter);
 
             return (value, versionBefore);
+        }
+
+        // --------------------------------------------------------------------
+        // Internal helpers for lock-free transactional commit (CAS-based)
+        // --------------------------------------------------------------------
+
+        // Only acquire if the expected snapshot version is EVEN and equals the current version.
+        // This prevents "stealing" or advancing a version while someone else holds a reservation.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryAcquireForWrite(long expectedSnapshotVersion)
+        {
+            if ((expectedSnapshotVersion & 1L) != 0) return false; // must be even (unlocked)
+            return Interlocked.CompareExchange(
+                ref _version,
+                expectedSnapshotVersion + 1,   // make it odd: reserved
+                expectedSnapshotVersion        // expected even
+            ) == expectedSnapshotVersion;
+        }
+
+        /// <summary>
+        /// Writes the new value and releases the reservation by advancing version again.
+        /// Must be called only after a successful TryAcquireForWrite on this instance.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void WriteAndRelease(T value)
+        {
+            // Apply the new value first, then advance the version to release the reservation.
+            Volatile.Write(ref _boxedValue, value!);
+            Interlocked.Increment(ref _version); // from reserved to committed
+        }
+
+        /// <summary>
+        /// Releases a previously acquired reservation without writing a new value.
+        /// Used when the transaction aborts after acquiring reservations.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void ReleaseAfterAbort()
+        {
+            // Advance version to cancel the reservation (no value change).
+            Interlocked.Increment(ref _version);
         }
     }
 }

--- a/src/STMSharp/Core/Transaction.cs
+++ b/src/STMSharp/Core/Transaction.cs
@@ -1,6 +1,7 @@
 ﻿// (c) 2024-2025 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using STMSharp.Core.Interfaces;
+using System.Runtime.CompilerServices;
 
 namespace STMSharp.Core
 {
@@ -159,9 +160,12 @@ namespace STMSharp.Core
                 }
             }
 
-            // 1) Reserve all write-set vars using their own snapshot versions.
+            // 1) Reserve all write-set variables using a stable ordering
             //    Drive strictly by the write-set to avoid any set/key drift.
-            var acquired = new List<STMVariable<T>>(_writes.Count);
+            var writeKeys = _writes.Keys
+                .OrderBy(k => RuntimeHelpers.GetHashCode(k))
+                .ToArray();
+            var acquired = new List<STMVariable<T>>(writeKeys.Length);
 
             foreach (var w in _writes.Keys)
             {

--- a/src/STMSharp/Core/Transaction.cs
+++ b/src/STMSharp/Core/Transaction.cs
@@ -1,41 +1,47 @@
-﻿// (c) 2024 Francesco Del Re <francesco.delre.87@gmail.com>
+﻿// (c) 2024-2025 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using STMSharp.Core.Interfaces;
 
 namespace STMSharp.Core
 {
     /// <summary>
-    /// Software Transactional Memory transaction with optimistic validation.
-    /// - Read-your-own-writes: reads observe buffered writes within the same transaction.
-    /// - Write-set validation: variables first seen via Write are included in validation.
+    /// Software Transactional Memory transaction with optimistic read snapshots
+    /// and a lock-free CAS-based commit protocol (reserve → revalidate → write&release).
     ///
-    /// NOTE: No write-locks are taken here, so write-write races can still occur.
-    ///       A deterministic write-set locking phase can be added later to prevent lost updates.
+    /// Properties:
+    /// - Read-your-own-writes: reads observe buffered writes within the same transaction.
+    /// - Immutable snapshot: the first observation of each variable (read or write-first)
+    ///   captures a version used for validation and reservation; it is never refreshed.
+    /// - Commit uses version CAS to prevent write-write lost updates without runtime locks.
+    ///
+    /// Notes:
+    /// - Conflict and retry counters are static per closed generic type (Transaction&lt;T&gt;).
+    /// - Read-only transactions validate but never persist writes.
     /// </summary>
     public class Transaction<T>
     {
-        // Stores values read during the transaction
+        // Read cache and read-your-own-writes within this transaction
         private readonly Dictionary<ISTMVariable<T>, T> _reads = [];
 
-        // Stores values written during the transaction
+        // Buffered writes to be applied at commit time
         private readonly Dictionary<ISTMVariable<T>, T> _writes = [];
 
-        // Tracks the locked versions of STM variables
-        private readonly Dictionary<ISTMVariable<T>, int> _lockedVersions = [];
+        // Immutable snapshot: for each observed variable, the version seen at first observation
+        private readonly Dictionary<ISTMVariable<T>, long> _snapshotVersions = [];
 
-        // Internal global counters for conflicts and retries (thread-safe)
-        private static int _conflictCount = 0;
-        private static int _retryCount = 0;
+        // Global-ish counters (per closed generic type)
+        private static int _conflictCount = 0; // number of detected conflicts
+        private static int _retryCount = 0;    // number of failed attempts (that required a retry)
 
         private readonly bool _isReadOnly;
 
         /// <summary>
-        /// Gets the number of detected conflicts in a thread-safe manner.
+        /// Total number of detected conflicts (thread-safe read).
         /// </summary>
         public static int ConflictCount => Volatile.Read(ref _conflictCount);
 
         /// <summary>
-        /// Gets the number of retry attempts in a thread-safe manner.
+        /// Total number of retry attempts (thread-safe read).
         /// </summary>
         public static int RetryCount => Volatile.Read(ref _retryCount);
 
@@ -46,103 +52,176 @@ namespace STMSharp.Core
 
         /// <summary>
         /// Reads a value from an STM variable.
-        /// - If the variable was written in this transaction, returns the buffered value (read-your-own-writes).
-        /// - Otherwise, reads the current value and captures its version for later conflict detection.
+        /// - If written in this transaction, returns the buffered value (read-your-own-writes).
+        /// - Else takes a consistent (Value, Version) snapshot; the version is recorded
+        ///   once per variable and never refreshed for the lifetime of this transaction.
         /// </summary>
         public T Read(ISTMVariable<T> variable)
         {
             ArgumentNullException.ThrowIfNull(variable);
 
-            // 1) Read-your-own-writes
+            // Read-your-own-writes
             if (_writes.TryGetValue(variable, out var pending))
                 return pending;
 
-            // 2) Cached read
-            if (_reads.TryGetValue(variable, out var cachedValue))
-                return cachedValue;
+            // Cached read
+            if (_reads.TryGetValue(variable, out var cached))
+                return cached;
 
-            // 3) First access: take a consistent snapshot and remember its version
+            // First observation: capture value and immutable snapshot version
             var (value, version) = variable.ReadWithVersion();
             _reads[variable] = value;
-            if (!_lockedVersions.ContainsKey(variable))
-                _lockedVersions[variable] = version; // include in validation set
+            if (!_snapshotVersions.ContainsKey(variable))
+                _snapshotVersions[variable] = version;
             return value;
         }
 
         /// <summary>
-        /// Buffers a write to the STM variable (deferred until commit).
-        /// Also ensures the variable is part of the validation set (write-set validation).
+        /// Buffers a write to the STM variable (deferred until commit) and guarantees
+        /// read-your-own-writes semantics. Captures the snapshot version only if this is
+        /// the first observation of the variable.
         /// </summary>
         public void Write(ISTMVariable<T> variable, T value)
         {
             ArgumentNullException.ThrowIfNull(variable);
 
-            // Buffer the write
-            _writes[variable] = value;
+            if (_isReadOnly)
+                throw new InvalidOperationException("Cannot Write in a read-only transaction.");
 
-            // Ensure subsequent reads in this transaction see the new value
+            // Buffer the write and ensure subsequent reads see it
+            _writes[variable] = value;
             _reads[variable] = value;
 
-            // If this variable wasn't observed before, capture its current version
-            // so that CheckForConflicts() also validates this write.
-            if (!_lockedVersions.ContainsKey(variable))
+            // Capture immutable snapshot on first observation only
+            if (!_snapshotVersions.ContainsKey(variable))
             {
                 var (_, version) = variable.ReadWithVersion();
-                _lockedVersions[variable] = version;
+                _snapshotVersions[variable] = version;
             }
         }
 
         /// <summary>
-        /// Checks for conflicts on all accessed STM variables (reads & writes)
-        /// by comparing their current version against the version locked at read time.
+        /// Validates the immutable snapshot: for each observed variable, the current version
+        /// must still match the captured snapshot version. Returns true if a conflict is found.
+        /// Increments the conflict counter once per failing call.
         /// </summary>
         public bool CheckForConflicts()
         {
-            foreach (var kvp in _lockedVersions)
+            foreach (var kvp in _snapshotVersions)
             {
-                ISTMVariable<T> variable = kvp.Key;
-                int lockedVersion = kvp.Value;
+                var variable = kvp.Key;
+                var snapshotVersion = kvp.Value;
 
-                if (variable.Version != lockedVersion)
+                if (variable.Version != snapshotVersion)
                 {
-                    // Increment conflict counter in a thread-safe way
                     Interlocked.Increment(ref _conflictCount);
                     return true;
                 }
             }
-
             return false;
         }
 
         /// <summary>
         /// Attempts to commit the transaction.
-        /// Returns true if validation succeeds and writes are applied (if not read-only).
+        /// Returns true if validation succeeds and (for non read-only) writes are applied.
         ///
-        /// NOTE: This is still an optimistic commit without write-locks, so concurrent
-        /// write-write races can exist. In a subsequent step we can introduce a
-        /// deterministic write-set locking protocol to eliminate lost updates.
+        /// Lock-free CAS protocol:
+        /// 0) Ensure every write-set variable has an immutable snapshot (defensive).
+        /// 1) Reserve each write-set variable by CAS-ing its version from snapshot to snapshot+1.
+        /// 2) Re-validate the entire observed snapshot (read- and write-sets).
+        /// 3) Apply buffered writes and release reservations by advancing version again.
         /// </summary>
         public bool Commit()
         {
-            if (CheckForConflicts())
+            // Fast path: read-only or no writes → snapshot validation only
+            if (_isReadOnly || _writes.Count == 0)
             {
-                // Increment retry count if conflict occurred
-                Interlocked.Increment(ref _retryCount);
-                Clear(); 
-                return false; // Abort due to conflict
+                if (CheckForConflicts())
+                {
+                    Interlocked.Increment(ref _retryCount);
+                    // CheckForConflicts() already bumped _conflictCount
+                    Clear();
+                    return false;
+                }
+                Clear();
+                return true;
             }
 
-            // Skip commit phase if the transation is read only
-            if (!_isReadOnly && _writes.Count > 0)
+            // 0) Defensive: every write must have a snapshot captured at first observation
+            foreach (var w in _writes.Keys)
             {
-                // Commit writes to variables, once confirmed that no conflict occurred
-                foreach (var entry in _writes)
+                if (!_snapshotVersions.ContainsKey(w))
                 {
-                    var variable = entry.Key;
-                    var value = entry.Value;
-
-                    variable.Write(value); // Apply the write to the STM variable
+                    Interlocked.Increment(ref _retryCount);
+                    Interlocked.Increment(ref _conflictCount);
+                    Clear();
+                    return false;
                 }
+            }
+
+            // 1) Reserve all write-set vars using their own snapshot versions.
+            //    Drive strictly by the write-set to avoid any set/key drift.
+            var acquired = new List<STMVariable<T>>(_writes.Count);
+
+            foreach (var w in _writes.Keys)
+            {
+                var snapVersion = _snapshotVersions[w];
+
+                // Must be the concrete STMVariable<T> to use CAS helpers
+                if (w is not STMVariable<T> concrete)
+                {
+                    Interlocked.Increment(ref _retryCount);
+                    Interlocked.Increment(ref _conflictCount);
+                    Clear();
+                    return false;
+                }
+
+                // Try to reserve according to the immutable snapshot
+                if (!concrete.TryAcquireForWrite(snapVersion))
+                {
+                    // Release any prior reservations and abort
+                    foreach (STMVariable<T> c in acquired)
+                        c.ReleaseAfterAbort();
+
+                    Interlocked.Increment(ref _retryCount);
+                    Interlocked.Increment(ref _conflictCount);
+                    Clear();
+                    return false;
+                }
+
+                acquired.Add(concrete);
+            }
+
+            // 2) Re-validate the entire observed snapshot (read-set + write-set).
+            foreach (var kvp in _snapshotVersions)
+            {
+                var variable = kvp.Key;
+                var snapVersion = kvp.Value;
+
+                if (_writes.ContainsKey(variable))
+                    continue; // write-set entries are already reserved by us
+
+                // Must still equal the snapshot and must not be reserved by someone else
+                var cur = variable.Version;
+                if (cur != snapVersion || (cur & 1) != 0)
+                {
+                    foreach (STMVariable<T> c in acquired)
+                        c.ReleaseAfterAbort();
+
+                    Interlocked.Increment(ref _retryCount);
+                    Interlocked.Increment(ref _conflictCount);
+                    Clear();
+                    return false;
+                }
+            }
+
+            // 3) Apply writes and release reservations (advance version again)
+            foreach (var kvp in _writes)
+            {
+                var variable = kvp.Key;
+                var value = kvp.Value;
+
+                ((STMVariable<T>)variable).WriteAndRelease(value);
             }
 
             Clear();
@@ -150,17 +229,17 @@ namespace STMSharp.Core
         }
 
         /// <summary>
-        /// Clears internal state after commit or abort.
+        /// Clears per-transaction state after commit or abort.
         /// </summary>
         private void Clear()
         {
             _reads.Clear();
             _writes.Clear();
-            _lockedVersions.Clear();
+            _snapshotVersions.Clear();
         }
 
         /// <summary>
-        /// Resets the global counters for conflicts and retries.
+        /// Resets global counters (per closed generic type).
         /// </summary>
         public static void ResetCounters()
         {


### PR DESCRIPTION
## Summary
This PR hardens STMSharp’s CAS-based commit protocol by:
1. Deterministic reservation order for the write-set to prevent livelock and inconsistent acquisition.
2. Removal of non-transactional mutations from the public API to preserve the even/odd version invariant and avoid out-of-band corruption.

Also updates the README with a dedicated section describing the CAS protocol and invariants.